### PR TITLE
chore: expand .gitignore for OS, editors, and Node tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,49 @@
+# --- macOS ---
 .DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+
+# --- Windows ---
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# --- Linux ---
+*~
+.directory
+.fuse_hidden*
+
+# --- Editors / IDEs ---
 .vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+*.swp
+*.swo
+
+# --- Node tooling (tokens/build.mjs) ---
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.npm/
+.eslintcache
+
+# --- Environment / secrets ---
+.env
+.env.*
+!.env.example
+
+# --- Design tool artifacts ---
+*.sketch~
+*.afdesign~
+.~lock.*
+*.tmp
+
+# --- Logs ---
+*.log


### PR DESCRIPTION
## Summary
Expands the `.gitignore` (previously just `.DS_Store` and `.vscode/`) to cover common cruft for a shareable design-asset repo.

## Changes
- **OS** — fuller macOS set plus Windows and Linux equivalents
- **Editors/IDEs** — JetBrains, Sublime, and Vim swap files alongside VS Code
- **Node tooling** — `node_modules/`, lockfile debug logs, `.eslintcache` (covers `tokens/build.mjs` if deps are ever added)
- **Secrets** — `.env*` with a `!.env.example` exception
- **Design-tool artifacts** — Sketch/Affinity temp/lock files, stray `*.tmp`/`*.log`

## Notes
Verified no currently tracked files become ignored — actual artwork (PNGs, SVGs, tokens, README) is unaffected.